### PR TITLE
fix: Resolve validation errors on listing/creating models with ImageField, DateTimeField, and ForeignKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Cache files
 *.pyc
-
+.history
 
 # Build output
 /*egg-info

--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@
 
 By leveraging Django Ninja, Lazy Ninja benefits from automatic, interactive API documentation generated through OpenAPI, giving developers an intuitive interface to quickly visualize and interact with API endpoints.
 
-  
+
+## Important Note: Current limitations (JSON Only)
+
+This current version of `lazy-ninja` **only supports JSON data** for request and response bodies.  `multipart/form-data` is *not* currently supported.  This means that direct file uploads through the generated API routes are *not* possible in this version.
+
+**Workaround for File/Image fields:**
+
+If your models have `ImageField` or `FileField` fields, you should treat them as simple string fields (URLs) in this version:
+
+1.  **Upload files separately:** Handle file uploads *outside* of `lazy-ninja` (e.g., using a separate service, a custom Django view, or a frontend library).
+2.  **Store the URL:**  Store the *full URL* of the uploaded file in the corresponding `ImageField` or `FileField` of your model.
+3.  **API interaction:**  When creating or updating objects via the `lazy-ninja` API, pass the URL string in the JSON payload.
+
+Support for `multipart/form-data` and direct file uploads is planned for a future version (see the [Roadmap](#roadmap)).
 
 ----------
 
@@ -17,6 +30,7 @@ By leveraging Django Ninja, Lazy Ninja benefits from automatic, interactive API 
   <summary>Table of Contents</summary>
   
 - [Lazy Ninja 🥷](#lazy-ninja-)
+  - [Important Note: Current limitations (JSON Only)](#important-note-current-limitations-json-only)
   - [Installation](#installation)
   - [Quick Start](#quick-start)
   - [Features](#features)
@@ -33,7 +47,7 @@ By leveraging Django Ninja, Lazy Ninja benefits from automatic, interactive API 
 
 ----------
 
-  
+
 
 ## Installation
 
@@ -260,15 +274,31 @@ To use custom controllers:
 
 ## Roadmap
 
- - [ ] **Authentication and RBAC:**  
-           Planned integration of token-based authentication (e.g., JWT) and role-based access control to protect automatically generated
-       routes.
-
- - [ ] **Centralized schema and security Config:**  
-           Future versions may allow combining schema customization and security settings into a single configuration object.
-
- - [ ] **Advanced model relationships:**  
-           Improved handling of relationships (foreign keys, many-to-many) and support for nested schemas.
+- [x] **Basic CRUD operations:**  Support for listing, retrieving, creating, updating, and deleting objects for Django models (JSON only).
+- [ ] **File upload:**
+    - [ ] Support for `multipart/form-data` uploads.
+    - [ ] Configurable automatic handling of `ImageField` and `FileField`.
+    - [ ] Option for custom upload handling via hooks.
+    - [ ] Support single and multiple files fields.
+- [ ] **Asynchronous operations:**
+    - [ ] Make all CRUD operations asynchronous by default (using Django's async ORM).
+    - [ ] Provide an option to use synchronous operations for specific models or globally.
+- [ ] **Authentication and RBAC:**
+    - [ ] Planned integration of token-based authentication.
+    - [ ] Role-based access control to protect automatically generated routes.
+- [ ] **Centralized schema and security config:**
+    - [ ] Future versions may allow combining schema customization and security settings into a single configuration object.
+- [ ] **Advanced model relationships:**
+    - [ ] Improved handling of relationships (foreign keys, many-to-many).
+    - [ ] Support for nested schemas.
+- [ ] **Filtering and sorting:**
+    - [ ] Built-in support for filtering and sorting list results based on query parameters.
+- [ ] **Pagination:**
+    - [ ] Configurable pagination for list results.
+- [ ] **Customizable endpoints:**
+     - [ ] Allow to add custom extra endpoints.
+- [ ] **API versioning:**
+    - [ ] Built-in support for API versioning.
 
 
 ## License

--- a/src/lazy_ninja/base.py
+++ b/src/lazy_ninja/base.py
@@ -1,6 +1,5 @@
 from abc import ABC
-from typing import Any, List
-from ninja import Schema
+from typing import Any
 
 class BaseModelController(ABC):
     """

--- a/src/lazy_ninja/builder.py
+++ b/src/lazy_ninja/builder.py
@@ -70,10 +70,13 @@ class DynamicAPI:
 
             else:
                 model_config = self.schema_config.get(model_name, {})
-                exclude_fields = list(model_config.get("exclude", []))
-                if "id" not in exclude_fields:
-                    exclude_fields.insert(0, "id")
-
+                exclude_fields = model_config.get("exclude", [
+                    "id", 
+                    "created_at", 
+                    "updated_at", 
+                    "deleted_at"
+                ])
+                
                 optional_fields = model_config.get("optional_fields", [])
 
                 list_schema = generate_schema(model)


### PR DESCRIPTION
This PR fixes validation errors that occurred during listing and creation of model objects containing `ImageField`, `DateTimeField`, and `ForeignKey` fields. These errors occurred even when file uploads were not actively used, due to incorrect assumptions about how Pydantic's `from_attributes=True` interacts with Django's `ImageField` and incorrect handling of `DateTimeField` and `ForeignKey` in serialization..

**Changes:**

*   **`utils.py`:**
    *   Added function `serialize_model_instance` for correct serialization of model instances, handling `ImageField`, `DateTimeField`, and `ForeignKey` fields correctly.
    *   Added function `convert_foreign_keys` to correctly convert foreign instances to IDs during creation and update.
    *   Fixed `get_pydantic_type` function to ensure correct type mapping for Pydantic schema generation.
*   **`routes.py`:**
     * Use the `convert_foreign_keys` in create and update item functions.

**Reasoning:**

The previous implementation made incorrect assumptions about how `ImageField` values are handled when `from_attributes=True` in Pydantic schemas. The `serialize_model_instance` function now correctly serializes these fields, along with `DateTimeField` (to ISO 8601 strings) and `ForeignKey` (to integer IDs), before Pydantic validation. The `convert_foreign_keys` function handles converting related object IDs to instances during creation and update.

**Testing:**
*   Manually tested listing and creating objects with models containing `ImageField`, `DateTimeField`, and `ForeignKey` fields.
*   Verified that no `ValidationError` occurs.
*   Verified that the correct data (URLs as strings, date/time strings, and foreign key IDs) is returned in the API response.

**Related Issue:**

Fixes #9 