### PR TITLE
hotfix: Add missing dependency `inflect`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "django>=4.2",
     "django-ninja>=0.22",
     "pydantic>=2.0",
+    "inflect>=7.5"
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
### Summary

This PR fixes a `ModuleNotFoundError` that occurs when importing modules that rely on `inflect`. The package was used in `lazy_ninja/builder.py` but was not declared as a dependency.

### Changes

- Added `inflect` to the dependencies list in `pyproject.toml`.

### Why

Without this fix, users installing the library in a fresh environment will encounter a runtime error unless they manually install `inflect`.

### Related Issue

Fixes #27 