### PR TITLE
Add Multipart Upload Functionality and Custom Middleware for PUT/PATCH Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add `api.urls` to your `urls.py` to expose the endpoints.
 - [x] Basic CRUD operations  
 - [x] Asynchronous support  
 - [x] Filtering, sorting, and pagination  
-- [ ] File upload support  
+- [X] File upload support  
 - [ ] Authentication and RBAC  
 - [ ] Advanced model relationships  
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Lazy Ninja 
 
-**Lazy Ninja** is a Django library that simplifies the creation of CRUD API endpoints using Django Ninja. It dynamically scans your Django models and generates Pydantic schemas for listing, retrieving, creating, and updating records. The library also allows you to customize behavior through hook functions (controllers) and schema configurations.
+**Lazy Ninja** is a Django library that simplifies the generation of API endpoints using Django Ninja. It dynamically scans your Django models and generates Pydantic schemas for listing, retrieving, creating, and updating records. The library also allows you to customize behavior through hook functions (controllers) and schema configurations.
 
 By leveraging Django Ninja, Lazy Ninja provides automatic, interactive API documentation via OpenAPI, making it easy to visualize and interact with your endpoints.
 
@@ -45,7 +45,7 @@ Add `api.urls` to your `urls.py` to expose the endpoints.
 
 ## Features
 
-- **Automatic CRUD Endpoints**: Instantly generate API routes for your Django models.
+- **Automatic Endpoints**: Instantly generate API routes for your Django models.
 - **Dynamic Schema Generation**: Automatically create Pydantic schemas for your models.
 - **Custom Controllers**: Customize route behavior with hooks like `before_create` and `after_update`.
 - **Built-in Filtering, Sorting, and Pagination**: Simplify data handling with query parameters.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 By leveraging Django Ninja, Lazy Ninja provides automatic, interactive API documentation via OpenAPI, making it easy to visualize and interact with your endpoints.
 
-> **Note:** This pre-release (alpha) version supports only JSON data. `multipart/form-data` (file uploads) is not yet available. For `ImageField` or `FileField`, use the full URL as a string.
-
 ---
 
 ## Installation

--- a/docs/docs/en/index.md
+++ b/docs/docs/en/index.md
@@ -278,11 +278,12 @@ api = DynamicAPI(api, pagination_type="page-number")
 
 Alternatively, set NINJA_PAGINATION_CLASS in settings.py to override the default globally.
 
-### File Upload Support
+---
+## File Upload Support
 
 Lazy Ninja now supports handling file uploads for models with `FileField` and `ImageField` using `multipart/form-data`. This feature allows you to define which fields should use `multipart/form-data` and provides flexibility to handle mixed models where some routes use JSON while others use `multipart/form-data`.
 
-#### How to Use File Upload Parameters
+### How to Use File Upload Parameters
 
 When initializing `DynamicAPI`, you can configure the following parameters:
 
@@ -292,7 +293,7 @@ When initializing `DynamicAPI`, you can configure the following parameters:
 - **`auto_detect_files`**: Automatically detect `FileField` and `ImageField` in models (default: `True`).
 - **`auto_multipart`**: Automatically enable `multipart/form-data` for models with detected file fields (default: `True`).
 
-#### Example Usage
+### Example Usage
 ```python
 from ninja import NinjaAPI
 from lazy_ninja.builder import DynamicAPI
@@ -323,14 +324,14 @@ In this example:
 
 ---
 
-### Custom Middleware for PUT/PATCH with Multipart
+## Custom Middleware for PUT/PATCH with Multipart
 
 To handle `PUT` and `PATCH` requests with `multipart/form-data`, Lazy Ninja includes a custom middleware: `ProcessPutPatchMiddleware`. This middleware ensures that `PUT` and `PATCH` requests are processed correctly by temporarily converting them to `POST` for form data handling.
 
-#### Why This Middleware is Needed
+### Why This Middleware is Needed
 Django has a known limitation where `PUT` and `PATCH` requests with `multipart/form-data` are not processed correctly. While Django Ninja recently introduced updates to address this, certain scenarios still require a custom solution. This middleware resolves those issues and ensures compatibility with both synchronous and asynchronous request handlers.
 
-#### How to Use the Middleware
+### How to Use the Middleware
 Add the middleware to your Django project's `MIDDLEWARE` setting:
 ```python
 MIDDLEWARE = [
@@ -340,14 +341,14 @@ MIDDLEWARE = [
 ]
 ```
 
-#### How It Works
+### How It Works
 - Converts `PUT` and `PATCH` requests with `multipart/form-data` to `POST` temporarily for proper processing.
 - Restores the original HTTP method after processing the request.
 
 ---
 
-### Contributing & Feedback
+## Contributing & Feedback
 Lazy Ninja is still evolving — contributions, suggestions, and feedback are more than welcome! Feel free to open issues, discuss ideas, or submit PRs.
 
-### License
+## License
 This project is licensed under the terms of the MIT license.

--- a/docs/docs/en/index.md
+++ b/docs/docs/en/index.md
@@ -1,13 +1,10 @@
-# Lazy Ninja: Generate CRUD API Endpoints for Django
+# Lazy Ninja: Generate API Endpoints for Django
 
 [![PyPI version](https://badge.fury.io/py/lazy-ninja.svg)](https://badge.fury.io/py/lazy-ninja)
 [![Downloads](https://static.pepy.tech/personalized-badge/lazy-ninja?period=total&units=international_system&left_color=grey&right_color=blue&left_text=Downloads)](https://pepy.tech/project/lazy-ninja)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
->**Note:** This version supports only JSON data. `multipart/form-data` (file uploads) is not yet available. For `ImageField` or `FileField`, use the full URL as a string
-
-
-**Lazy Ninja** is a Django library that automates the generation of CRUD API endpoints with Django Ninja. It dynamically scans your Django models and creates Pydantic schemas for listing, detailing, creating, and updating records—all while allowing you to customize behavior via hook functions (controllers) and schema configurations.
+**Lazy Ninja** is a Django library that automates the generation of API endpoints with Django Ninja. It dynamically scans your Django models and creates Pydantic schemas for listing, detailing, creating, and updating records—all while allowing you to customize behavior via hook functions (controllers) and schema configurations.
 
 By leveraging Django Ninja, Lazy Ninja benefits from automatic, interactive API documentation generated through OpenAPI (Swagger UI and ReDoc), giving developers an intuitive interface to quickly visualize and interact with API endpoints.
 
@@ -15,7 +12,7 @@ By leveraging Django Ninja, Lazy Ninja benefits from automatic, interactive API 
 
 **Key Features:**
 
--   **Instant CRUD Endpoints:** Automatically generate API endpoints from Django models.
+-   **Instant API Endpoints:** Automatically generate API endpoints from Django models.
 -   **Dynamic Schema Generation:** Automatically create Pydantic models.
 -   **Customizable Hooks:** Add pre-processing, post-processing, or custom logic to routes by creating controllers for specific models.
 -   **Smart Filtering/Sorting:** Built-in support for filters like `field=value` or `field>value`.
@@ -96,7 +93,7 @@ python manage.py runserver
 
 ## Instant API Endpoints
 
-Your CRUD API is now live at  `http://localhost:8000/api`  with these endpoints:
+Your API is now live at  `http://localhost:8000/api`  with these endpoints:
 
 | Method |  URL               | Action         |
 | ------ | -------------------| ---------------| 
@@ -280,6 +277,77 @@ api = DynamicAPI(api, pagination_type="page-number")
 ```
 
 Alternatively, set NINJA_PAGINATION_CLASS in settings.py to override the default globally.
+
+### File Upload Support
+
+Lazy Ninja now supports handling file uploads for models with `FileField` and `ImageField` using `multipart/form-data`. This feature allows you to define which fields should use `multipart/form-data` and provides flexibility to handle mixed models where some routes use JSON while others use `multipart/form-data`.
+
+#### How to Use File Upload Parameters
+
+When initializing `DynamicAPI`, you can configure the following parameters:
+
+- **`file_fields`**: Specify which fields in a model should use `multipart/form-data`.
+- **`use_multipart`**: Explicitly define whether `create` and `update` operations for specific models should use `multipart/form-data`.
+- **`auto_multipart`**: Automatically detect file fields in models and enable `multipart/form-data` for them (default: `True`).
+- **`auto_detect_files`**: Automatically detect `FileField` and `ImageField` in models (default: `True`).
+- **`auto_multipart`**: Automatically enable `multipart/form-data` for models with detected file fields (default: `True`).
+
+#### Example Usage
+```python
+from ninja import NinjaAPI
+from lazy_ninja.builder import DynamicAPI
+
+api = NinjaAPI()
+
+auto_api = DynamicAPI(
+    api,
+    is_async=True,
+    file_fields={"Gallery": ["images"], "Product": ["pimages"]},  # Specify file fields
+    use_multipart={
+        "Product": {
+            "create": True,  # Use multipart/form-data for creation
+            "update": True   # Use multipart/form-data for updates
+        }
+    },
+    auto_detect_files=True,  # Automatically detect file fields in models
+    auto_multipart=True      # Automatically enable multipart/form-data for detected file fields
+)
+
+auto_api.register_all_models()
+```
+
+In this example:
+- The `Gallery` model will use `multipart/form-data` for the `images` field.
+- The `Product` model will use `multipart/form-data` for the `pimages` field during `create` and `update` operations.
+- Models without file fields will continue to use JSON by default.
+
+---
+
+### Custom Middleware for PUT/PATCH with Multipart
+
+To handle `PUT` and `PATCH` requests with `multipart/form-data`, Lazy Ninja includes a custom middleware: `ProcessPutPatchMiddleware`. This middleware ensures that `PUT` and `PATCH` requests are processed correctly by temporarily converting them to `POST` for form data handling.
+
+#### Why This Middleware is Needed
+Django has a known limitation where `PUT` and `PATCH` requests with `multipart/form-data` are not processed correctly. While Django Ninja recently introduced updates to address this, certain scenarios still require a custom solution. This middleware resolves those issues and ensures compatibility with both synchronous and asynchronous request handlers.
+
+#### How to Use the Middleware
+Add the middleware to your Django project's `MIDDLEWARE` setting:
+```python
+MIDDLEWARE = [
+    ...
+    'lazy_ninja.middleware.ProcessPutPatchMiddleware',
+    ...
+]
+```
+
+#### How It Works
+- Converts `PUT` and `PATCH` requests with `multipart/form-data` to `POST` temporarily for proper processing.
+- Restores the original HTTP method after processing the request.
+
+---
+
+### Contributing & Feedback
+Lazy Ninja is still evolving — contributions, suggestions, and feedback are more than welcome! Feel free to open issues, discuss ideas, or submit PRs.
 
 ### License
 This project is licensed under the terms of the MIT license.

--- a/src/lazy_ninja/__init__.py
+++ b/src/lazy_ninja/__init__.py
@@ -9,16 +9,7 @@ from .base import BaseModelController
 from .helpers import get_hook
 from .registry import ModelRegistry, controller_for
 from .routes import register_model_routes_internal
-from .middleware import ErrorHandlingMiddleware
-
-__all__ = [
-    'ErrorHandlingMiddleware',
-    'LazyNinjaError',
-    'NotFoundError',
-    'ValidationError',
-    'DatabaseOperationError',
-    'SynchronousOperationError',
-]
+from .file_upload import FileUploadConfig
 
 def register_model_routes(
     api: NinjaAPI,
@@ -29,31 +20,37 @@ def register_model_routes(
     create_schema: Optional[Type[Schema]] = None,
     update_schema: Optional[Type[Schema]] = None,
     pagination_strategy: Optional[str] = None,
+    file_upload_config: Optional[FileUploadConfig] = None,
+    use_multipart_create: bool = False,
+    use_multipart_update: bool = False,
     is_async: bool = True
 ) -> None:
     """
     Main function to register CRUD routes for a Django model using Django Ninja.
 
-    Parameters:
-      - api: Instance of NinjaAPI.
-      - model: The Django model class.
-      - base_url: Base URL for the resource endpoints.
-      - list_schema: Pydantic schema for listing objects.
-      - detail_schema: Pydantic schema for retrieving object details.
-      - create_schema: (Optional) Pydantic schema for creating an object.
-      - update_schema: (Optional) Pydantic schema for updating an object.
+    Args:
+        api: NinjaAPI instance.
+        model: Django model class.
+        base_url: Base URL for the routes.
+        list_schema: Schema for list responses.
+        detail_schema: Schema for detail responses.
+        create_schema: (Optional) Schema for create requests.
+        update_schema: (Optional) Schema for update requests.
+        pagination_strategy: (Optional) Strategy for pagination.
+        file_upload_config: (Optional) Configuration for file uploads.
+        use_multipart_create: Whether to use multipart/form-data for create endpoint.
+        use_multipart_update: Whether to use multipart/form-data for update endpoint.
+        is_async: Whether to use async routes (default: True).
 
     This function retrieves the registered controller for the model (if any)
     and passes its hooks to the internal route registration function.
     """
-    # Retrieve the custom controller for the model; use BaseModelController if none is registered.
     ModelRegistry.discover_controllers()
 
     controller = ModelRegistry.get_controller(model.__name__)
     if not controller:
         controller = BaseModelController
     
-    # Call the internal function that sets up the router and registers all endpoints.
     register_model_routes_internal(
         api=api,
         model=model,
@@ -71,5 +68,8 @@ def register_model_routes(
         after_delete=get_hook(controller, 'after_delete'),
         custom_response=get_hook(controller, 'custom_response'),
         pagination_strategy=pagination_strategy,
+        file_upload_config=file_upload_config,
+        use_multipart_create=use_multipart_create,
+        use_multipart_update=use_multipart_update,
         is_async=is_async
     )

--- a/src/lazy_ninja/file_upload.py
+++ b/src/lazy_ninja/file_upload.py
@@ -1,0 +1,100 @@
+from typing import Dict, List, Tuple
+
+from django.db import models
+
+class FileUploadConfig:
+    """
+    Configuration for file upload fields in a model.
+    
+    This class helps configure which fields are file fields and
+    whether to use multipart/form-data for specific models.
+    """
+    def __init__(
+        self,
+        file_fields: Dict[str, List[str]] = None,
+        multiple_file_fields: Dict[str, List[str]] = None,
+    ):
+        """
+        Initialize file upload configuration.
+        
+        Args:
+            file_fields: Dictionary mapping model names to lists of file field names
+                         e.g. {"MyModel": ["image", "attachment"]}
+            multiple_file_fields: Dictionary mapping model names to lists of field names 
+                                  that can accept multiple files
+                                  e.g. {"MyModel": ["gallery_images"]}
+        """
+        self.file_fields = file_fields or {}
+        self.multiple_file_fields = multiple_file_fields or {}
+        
+    def get_model_file_fields(self, model_name: str) -> List[str]:
+        """Get list of file fields for a model."""
+        return self.file_fields.get(model_name, [])
+    
+    def get_model_multiple_file_fields(self, model_name: str) -> List[str]:
+        """Get list of multiple file fields for a model."""
+        return self.multiple_file_fields.get(model_name, [])
+    
+    def is_multiple_file_field(self, model_name: str, field_name: str) -> bool:
+        """Check if a field is configured for multiple file uploads."""
+        return field_name in self.get_model_multiple_file_fields(model_name)
+
+
+def detect_file_fields(model) -> Tuple[List[str], List[str]]:
+    """
+    Automatically detect file fields in a Django model.
+    
+    Returns a tuple of (single_file_fields, multiple_file_fields)
+    """
+    single_file_fields = []
+    multiple_file_fields = []
+    
+    for field in model._meta.get_fields():
+        if isinstance(field, (models.FileField, models.ImageField)):
+            single_file_fields.append(field.name)
+            
+        elif isinstance(field, models.ManyToManyField):
+            related_model = field.related_model
+            if related_model:
+                
+                for related_field in related_model._meta.get_fields():
+                    if isinstance(related_field, (models.FileField, models.ImageField)):
+                        multiple_file_fields.append(field.name)
+                        break
+                    
+        elif isinstance(field, models.ManyToOneRel):
+            related_model = field.related_model
+            if related_model:
+                has_file_field = False
+                
+                for related_field in related_model._meta.get_fields():
+                    if isinstance(related_field, (models.FileField, models.ImageField)):
+                        has_file_field = True
+                        break
+                    
+                if has_file_field:
+                    multiple_file_fields.append(field.get_accessor_name())
+                    
+        elif isinstance(field, models.OneToOneField):
+            related_model = field.related_model
+            if related_model:
+                
+                for related_model in related_model._meta.get_fields():
+                    if isinstance(related_field, (models.FileField, models.ImageField)):
+                        single_file_fields.append(field.name)
+                        break
+                    
+        elif isinstance(field, models.OneToOneRel):
+            related_model = field.related_model
+            if related_model:
+                has_file_field = False
+                
+                for related_field in related_model._meta.get_fields():
+                    if isinstance(related_field, (models.FileField, models.ImageField)):
+                        has_file_field = True
+                        break
+                
+                if has_file_field:
+                    single_file_fields.append(field.get_accessor_name())
+            
+    return single_file_fields, multiple_file_fields

--- a/src/lazy_ninja/middleware/__init__.py
+++ b/src/lazy_ninja/middleware/__init__.py
@@ -1,1 +1,2 @@
 from .error_handling import ErrorHandlingMiddleware
+from .process_put_patch import ProcessPutPatchMiddleware

--- a/src/lazy_ninja/middleware/process_put_patch.py
+++ b/src/lazy_ninja/middleware/process_put_patch.py
@@ -1,0 +1,33 @@
+from asgiref.sync import sync_to_async, iscoroutinefunction
+
+from django.http import HttpRequest
+from django.utils.deprecation import MiddlewareMixin
+
+class ProcessPutPatchMiddleware(MiddlewareMixin):
+    """
+    Middleware to handle PUT/PATCH requests as POST for form data processing
+    Works for both synchronous and asynchronous request handlers
+    """
+    
+    def _core_processing(self, request: HttpRequest) -> None:
+        if request.method in ("PUT", "PATCH") and request.content_type != "application/json":
+            original_method = request.method
+            request.method = "POST"
+            request.META["REQUEST_METHOD"] = "POST"
+            
+            request._load_post_and_files()
+            
+            request.method = original_method
+            request.META["REQUEST_METHOD"] = original_method
+
+    def __call__(self, request: HttpRequest):
+        if iscoroutinefunction(self.get_response):
+            async def async_handler(request):
+                await sync_to_async(self._core_processing)(request)
+                response = await self.get_response(request)
+                return response
+            return async_handler(request)
+        else:
+            self._core_processing(request)
+            response = self.get_response(request)
+            return response


### PR DESCRIPTION
#### **Description**
This pull request introduces robust support for file uploads using `multipart/form-data` and includes a custom middleware to handle PUT/PATCH requests for multipart routes. While the primary goal is to enable file upload functionality, the middleware was added to address challenges encountered with Django handling of multipart updates, even after its recent updates.

---

#### **Key Changes**
1. **Multipart Upload Functionality**:
   - Added support for handling `FileField` and `ImageField` in Django models with `multipart/form-data`.
   - Automatically detects `FileField` and `ImageField` in models and generates routes for these fields using `multipart/form-data`.
   - Models without file fields continue to use `application/json` by default.
   - Introduced parameters for fine-grained control:
     - **`file_fields`**: Specify which fields in a model should use `multipart/form-data`.
     - **`use_multipart`**: Explicitly define whether `create` and `update` operations for specific models should use `multipart/form-data`.
     - **`auto_multipart`**: Automatically enable `multipart/form-data` for models with file fields (default: `True`).

2. **Custom Middleware for PUT/PATCH Handling**:
   - Added `ProcessPutPatchMiddleware` to handle `PUT` and `PATCH` requests as `POST` for proper form data processing.
   - This middleware resolves issues encountered with Django handling of multipart updates, ensuring compatibility with both synchronous and asynchronous request handlers.
   - Middleware usage:
     ```python
     MIDDLEWARE = [
         ...
         'lazy_ninja.middleware.ProcessPutPatchMiddleware',
         ...
     ]
     ```

---

#### **Example Usage**
```python
auto_api = DynamicAPI(
    api,
    is_async=True,
    file_fields={"Gallery": ["images"], "Product": ["pimages"]},  # Specify file fields
    use_multipart={
        "Product": {
            "create": True,  # Use multipart/form-data for creation
            "update": True   # Use multipart/form-data for updates
        }
    },
    auto_multipart=True  # Automatically detect file fields and use multipart
)
```

---

#### **Why This is Needed**
1. **Enable File Uploads**:
   - Provides a structured way to handle file uploads in Django models.
   - Supports mixed models where some routes use `multipart/form-data` and others use `application/json`.
   - Allows developers to override defaults and explicitly define behavior for specific models and operations.

2. **Custom Middleware**:
   - Django Ninja's recent updates for handling multipart updates did not work as expected in this library's context.
   - The custom middleware ensures that `PUT` and `PATCH` requests with `multipart/form-data` are processed correctly, enabling seamless updates for models with file fields.

---

#### **Next Steps**
- Expand documentation to include detailed examples of the new `file_fields`, `use_multipart`, and `auto_multipart` parameters.
- Add more test cases to ensure compatibility with various model configurations.

This PR introduces essential functionality for file uploads while addressing multipart update challenges. 