### PR TITLE
Feature - Add JWT Authentication Module

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install setuptools_scm  # Adicionado para versionamento dinâmico
+          pip install -r requirements.dev.txt
+          pip install setuptools_scm
 
       - name: Run tests
         run: pytest --cov=lazy_ninja --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "django-ninja>=0.22",
     "pydantic>=2.0",
     "inflect>=7.5",
-    "colorama>=0.4.6"
+    "colorama>=0.4.6",
+    "pyjwt>=2.0"
 ]
 
 classifiers = [
@@ -51,4 +52,3 @@ local_scheme = "no-local-version"
 
 [project.scripts]
 lazy-ninja = "lazy_ninja.cli.main:main"
-

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,7 @@
 inflect>=7.5.0
 openapi-generator-cli[jdk4py]>=7.0.0
 pytest-cov>=6.0.0
+pyjwt>=2.0
 colorama>=0.4.6
 pytest-django>=4.10.0
 mkdocs>=1.6.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
+lazy-ninja
 inflect>=7.5.0
 openapi-generator-cli[jdk4py]>=7.0.0
 pytest-cov>=6.0.0

--- a/src/lazy_ninja/auth.py
+++ b/src/lazy_ninja/auth.py
@@ -1,0 +1,290 @@
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Type, Any, Dict
+
+import jwt
+from django.conf import settings
+from django.contrib.auth import authenticate, get_user_model
+from django.db import transaction
+from django.db.models import Model
+from django.http import HttpResponse
+from django.utils import timezone as dj_timezone
+from jwt import ExpiredSignatureError, PyJWTError
+from ninja import NinjaAPI, Schema
+from ninja.errors import HttpError
+
+from .utils.schema import generate_schema
+
+
+def _auth_cfg() -> Dict[str, Any]:
+    return getattr(settings, "LAZY_NINJA_AUTH", {}) or {}
+
+
+def _get_setting(keys: list[str], default: Any = None) -> Any:
+    """Resolve setting from LAZY_NINJA_AUTH or Django settings."""
+    cfg = _auth_cfg()
+    for key in keys:
+        if key in cfg:
+            return cfg[key]
+        val = getattr(settings, key, None)
+        if val is not None:
+            return val
+    return default
+
+
+def _get_jwt_secret() -> str:
+    """Return the secret key used to sign JWTs."""
+    secret = _get_setting(["JWT_SECRET", "SECRET_KEY"])
+    if not secret:
+        raise RuntimeError("JWT secret is not configured.")
+    return str(secret)
+
+
+def _get_jwt_algorithm() -> str:
+    return _get_setting(["JWT_ALGORITHM"], "HS256")
+
+
+def _get_token_lifetimes() -> Dict[str, int]:
+    """Return access and refresh token lifetimes in seconds."""
+    return {
+        "access": int(_get_setting(["JWT_ACCESS_EXP"], 60 * 60 * 24)),
+        "refresh": int(_get_setting(["JWT_REFRESH_EXP"], 60 * 60 * 24 * 30)),
+    }
+
+
+def _cookie_secure_flag() -> bool:
+    return bool(_get_setting(["COOKIE_SECURE"], not getattr(settings, "DEBUG", False)))
+
+
+def register_auth_routes(
+    api: NinjaAPI,
+    *,
+    profile_model: Optional[Type[Model]] = None,
+    access_cookie_name: str = "lazy_ninja_access_token",
+    refresh_cookie_name: str = "lazy_ninja_refresh_token",
+    cookie_path: str = "/",
+    tags: Optional[list[str]] = None,
+) -> None:
+    """
+    Registers a full JWT-based authentication flow on the given NinjaAPI.
+
+    Endpoints added:
+        POST /auth/login
+        POST /auth/register
+        POST /auth/refresh
+        GET  /auth/me
+        POST /auth/logout
+    """
+    auth_tags = tags or ["Auth"]
+
+    User = get_user_model()
+    lifetimes = _get_token_lifetimes()
+
+    UserPublicSchema = generate_schema(User, exclude=["password"])
+    ProfileSchema = generate_schema(profile_model) if profile_model else None  # type: ignore[assignment]
+
+    class TokenPairSchema(Schema):
+        access: str
+        refresh: str
+
+    class AuthResponseSchema(TokenPairSchema):
+        user: UserPublicSchema  # type: ignore[valid-type]
+        profile: Optional[ProfileSchema] = None if ProfileSchema else None  # type: ignore[valid-type]
+
+    class LoginSchema(Schema):
+        email: str
+        password: str
+
+    class RegisterSchema(Schema):
+        email: str
+        password: str
+        username: Optional[str] = None
+        first_name: Optional[str] = None
+        last_name: Optional[str] = None
+
+    class RefreshSchema(Schema):
+        refresh: Optional[str] = None
+
+    class MeResponseSchema(Schema):
+        user: UserPublicSchema  # type: ignore[valid-type]
+        profile: Optional[ProfileSchema] = None if ProfileSchema else None  # type: ignore[valid-type]
+
+    def _generate_token(user: Any, *, expires_in: int, token_type: str) -> str:
+        now = datetime.now(timezone.utc)
+        payload = {
+            "sub": str(user.id),
+            "type": token_type,
+            "iat": int(now.timestamp()),
+            "exp": int((now + timedelta(seconds=expires_in)).timestamp()),
+        }
+        return jwt.encode(payload, _get_jwt_secret(), algorithm=_get_jwt_algorithm())
+
+    def _decode_token(token: str, expected_type: str) -> dict:
+        try:
+            payload = jwt.decode(
+                token,
+                _get_jwt_secret(),
+                algorithms=[_get_jwt_algorithm()],
+            )
+        except ExpiredSignatureError as exc:
+            raise HttpError(401, "Expired token.") from exc
+        except PyJWTError as exc:
+            raise HttpError(401, "Invalid token.") from exc
+
+        if payload.get("type") != expected_type:
+            raise HttpError(401, "Invalid token type.")
+        return payload
+
+    def _serialize_user(user: Any) -> dict:
+        return UserPublicSchema.model_validate(user).model_dump()
+
+    def _serialize_profile(profile: Optional[Any]) -> Optional[dict]:
+        if not profile or not ProfileSchema:
+            return None
+        return ProfileSchema.model_validate(profile).model_dump()
+
+    def _apply_auth_cookies(response: HttpResponse, access: str, refresh: Optional[str]) -> None:
+        secure_flag = _cookie_secure_flag()
+        response.set_cookie(
+            access_cookie_name,
+            access,
+            max_age=lifetimes["access"],
+            httponly=True,
+            secure=secure_flag,
+            samesite="Lax",
+            path=cookie_path,
+        )
+        if refresh:
+            response.set_cookie(
+                refresh_cookie_name,
+                refresh,
+                max_age=lifetimes["refresh"],
+                httponly=True,
+                secure=secure_flag,
+                samesite="Lax",
+            )
+
+    def _clear_auth_cookies(response: HttpResponse) -> None:
+        response.delete_cookie(access_cookie_name, path=cookie_path)
+        response.delete_cookie(refresh_cookie_name, path=cookie_path)
+
+    def _build_auth_payload(user: Any, *, rotate_refresh: bool = True) -> dict:
+        access = _generate_token(user, expires_in=lifetimes["access"], token_type="access")
+        refresh = (
+            _generate_token(user, expires_in=lifetimes["refresh"], token_type="refresh")
+            if rotate_refresh else None
+        )
+        return {
+            "access": access,
+            "refresh": refresh or "",
+            "user": _serialize_user(user),
+            "profile": _serialize_profile(getattr(user, "profile", None)),
+        }
+
+    def _token_from_request(request, expected_type: str) -> Optional[str]:
+        cookie_val = (
+            request.COOKIES.get(access_cookie_name)
+            if expected_type == "access"
+            else request.COOKIES.get(refresh_cookie_name)
+        )
+
+        auth_header = request.headers.get("Authorization") or ""
+        if auth_header.startswith("Bearer "):
+            return auth_header.split(" ", 1)[1]
+
+        return cookie_val
+
+    def _get_user_from_authorization(request, expected_type: str = "access") -> Any:
+        token = _token_from_request(request, expected_type)
+        if not token:
+            raise HttpError(401, "Missing credentials")
+
+        payload = _decode_token(token, expected_type)
+        user_id = payload.get("sub")
+
+        try:
+            user = User.objects.select_related("profile").get(id=user_id)
+        except User.DoesNotExist as exc:
+            raise HttpError(401, "User not found.") from exc
+        return user
+
+    def _build_response(request, payload: dict, *, status: int = 200) -> HttpResponse:
+        response = api.create_response(request, payload, status=status)
+        _apply_auth_cookies(response, payload["access"], payload.get("refresh"))
+        return response
+
+    @api.post("/auth/login", response=AuthResponseSchema, tags=auth_tags)
+    def login(request, payload: LoginSchema):
+        user = authenticate(request, username=payload.email, password=payload.password)
+        if not user:
+            raise HttpError(401, "Invalid credentials.")
+
+        user.last_login = dj_timezone.now()
+        user.save(update_fields=["last_login"])
+
+        return _build_response(request, _build_auth_payload(user))
+
+    @api.post("/auth/register", response=AuthResponseSchema, tags=auth_tags)
+    def register(request, payload: RegisterSchema):
+        if User.objects.filter(email__iexact=payload.email).exists():
+            raise HttpError(400, "E-mail already registered.")
+
+        with transaction.atomic():
+            user_kwargs: Dict[str, Any] = {
+                "email": payload.email,
+                "password": payload.password,
+                "username": payload.username or payload.email,
+            }
+
+            if hasattr(User, "first_name") and payload.first_name is not None:
+                user_kwargs["first_name"] = payload.first_name
+            if hasattr(User, "last_name") and payload.last_name is not None:
+                user_kwargs["last_name"] = payload.last_name
+
+            user = User.objects.create_user(**user_kwargs)  # type: ignore[attr-defined]
+
+            if profile_model and hasattr(user, "profile"):
+                profile = user.profile
+                if payload.first_name and hasattr(profile, "first_name"):
+                    profile.first_name = payload.first_name
+                if payload.last_name and hasattr(profile, "last_name"):
+                    profile.last_name = payload.last_name
+                profile.save()
+
+        return _build_response(request, _build_auth_payload(user))
+
+    @api.post("/auth/refresh", response=TokenPairSchema, tags=auth_tags)
+    def refresh_token(request, payload: RefreshSchema):
+        token_source = payload.refresh or _token_from_request(request, expected_type="refresh")
+        if not token_source:
+            raise HttpError(401, "Renewal token missing.")
+
+        data = _decode_token(token_source, expected_type="refresh")
+        user_id = data.get("sub")
+
+        try:
+            user = User.objects.get(id=user_id)
+        except User.DoesNotExist as exc:
+            raise HttpError(401, "User not found.") from exc
+
+        token_pair = {
+            "access": _generate_token(user, expires_in=lifetimes["access"], token_type="access"),
+            "refresh": _generate_token(user, expires_in=lifetimes["refresh"], token_type="refresh"),
+        }
+
+        response = api.create_response(request, token_pair, status=200)
+        _apply_auth_cookies(response, token_pair["access"], token_pair["refresh"])
+        return response
+
+    @api.get("/auth/me", response=MeResponseSchema, tags=auth_tags)
+    def me(request):
+        user = _get_user_from_authorization(request, expected_type="access")
+        return {
+            "user": _serialize_user(user),
+            "profile": _serialize_profile(getattr(user, "profile", None)),
+        }
+
+    @api.post("/auth/logout", tags=auth_tags)
+    def logout(request):
+        response = api.create_response(request, {"detail": "Logged out"}, status=200)
+        _clear_auth_cookies(response)
+        return response

--- a/src/lazy_ninja/builder.py
+++ b/src/lazy_ninja/builder.py
@@ -3,6 +3,8 @@ import inflect
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Set, Dict, List, Type, Union, Any
 
+from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.db import connection
 from django.apps import apps
 
@@ -13,6 +15,7 @@ from .utils import generate_schema
 from .helpers import to_kebab_case
 from .pagination import get_pagination_strategy
 from .file_upload import FileUploadConfig, detect_file_fields
+from .auth import register_auth_routes
 
 p = inflect.engine()
 
@@ -46,7 +49,7 @@ class ExclusionConfig:
         }
         
         if exclude:
-            self.excluded.update(exclude)
+            self.excluded.update(exclude) # type: ignore
             
     def should_exclude_model(self, model) -> bool:
         """
@@ -94,7 +97,13 @@ class DynamicAPI:
         auto_detect_files: bool = True,
         auto_multipart: bool = True,
         use_multipart: Optional[Dict[str, Dict[str, bool]]] = None,
-        is_async: bool = True
+        is_async: bool = True,
+        auth: Optional[bool] = None,
+        auth_profile_model: Optional[Type[Any]] = None,
+        auth_access_cookie_name: str = "lazy_ninja_access_token",
+        auth_refresh_cookie_name: str = "lazy_ninja_refresh_token",
+        auth_cookie_path: str = "/",
+        auth_tags: Optional[List[str]] = None,
     ):
         """
         Initializes the DynamicAPI instance.
@@ -117,6 +126,15 @@ class DynamicAPI:
             use_multipart: Dictionary specifying which models should use multipart/form-data
                            (e.g., {"Product": {"create": True, "update": True}}).
             is_async: Whether to use async routes (default: True).
+            auth: Enable built-in auth routes when True. If None, falls back
+                  to settings.LAZY_NINJA.get("auth", False).
+            auth_profile_model: Optional Django model class for a user profile
+                  (OneToOne with the user). If not provided, can be set via
+                  settings.LAZY_NINJA["profile_model"] as "app_label.ModelName".
+            auth_access_cookie_name: Name of the access token cookie.
+            auth_refresh_cookie_name: Name of the refresh token cookie.
+            auth_cookie_path: Cookie path for auth cookies.
+            auth_tags: Optional list of tags for auth endpoints.
                
         Pagination Configuration:
             The pagination can be configured in three ways (in order of precedence):
@@ -140,7 +158,32 @@ class DynamicAPI:
         self.file_upload_config = FileUploadConfig(
             file_fields=self.file_fields
         )
-        
+
+        lazy_cfg = getattr(settings, "LAZY_NINJA", {}) or {}
+        if auth is None:
+            self.auth_enabled = bool(lazy_cfg.get("auth", False))
+        else:
+            self.auth_enabled = bool(auth)
+
+        profile_model_setting = lazy_cfg.get("profile_model")
+        resolved_profile_model: Optional[Type[Any]] = auth_profile_model
+        if resolved_profile_model is None and profile_model_setting:
+            if isinstance(profile_model_setting, str):
+                try:
+                    resolved_profile_model = apps.get_model(profile_model_setting)
+                except LookupError:
+                    raise RuntimeError(
+                        f"Invalid LAZY_NINJA['profile_model']: {profile_model_setting!r}"
+                    )
+            elif isinstance(profile_model_setting, type):
+                resolved_profile_model = profile_model_setting
+
+        self.auth_profile_model = resolved_profile_model
+        self.auth_access_cookie_name = auth_access_cookie_name
+        self.auth_refresh_cookie_name = auth_refresh_cookie_name
+        self.auth_cookie_path = auth_cookie_path
+        self.auth_tags = auth_tags
+
         self._already_registered = False
         
     @staticmethod
@@ -150,10 +193,17 @@ class DynamicAPI:
     
     def _register_all_models_sync(self) -> None:
         existing_tables = self._get_existing_tables()
-            
+        try:
+            user_model = get_user_model()
+        except Exception:  # pragma: nocover - defensive
+            user_model = None
+
         for model in apps.get_models():
             app_label = model._meta.app_label
             model_name = model.__name__
+
+            if not getattr(self, "auth_enabled", False) and user_model and model is user_model:
+                continue
 
             if self.exclusion_config.should_exclude_model(model):
                 continue
@@ -164,10 +214,10 @@ class DynamicAPI:
             custom_schema = self.custom_schemas.get(model_name)
 
             if custom_schema:
-                list_schema = custom_schema.get("list") or generate_schema(model)  # Fallback to generated
-                detail_schema = custom_schema.get("detail") or generate_schema(model) # Fallback to generated
-                create_schema = custom_schema.get("create") # No fallback, required for create
-                update_schema = custom_schema.get("update") # No fallback, required for update
+                list_schema = custom_schema.get("list") or generate_schema(model)
+                detail_schema = custom_schema.get("detail") or generate_schema(model) 
+                create_schema = custom_schema.get("create") 
+                update_schema = custom_schema.get("update") 
 
             else:
                 model_config = self.schema_config.get(model_name, {})
@@ -211,12 +261,12 @@ class DynamicAPI:
             register_model_routes(
                 api=self.api,
                 model=model,
-                base_url=f"/{p.plural(to_kebab_case(model_name))}",
+                base_url=f"/{p.plural(to_kebab_case(model_name))}", # type: ignore
                 list_schema=list_schema,
                 detail_schema=detail_schema,
                 create_schema=create_schema,
                 update_schema=update_schema,
-                pagination_strategy=self.pagination_strategy,
+                pagination_strategy=self.pagination_strategy, # type: ignore
                 file_upload_config=self.file_upload_config if model_file_fields else None,
                 use_multipart_create=use_multipart_create,
                 use_multipart_update=use_multipart_update,
@@ -250,4 +300,19 @@ class DynamicAPI:
         This method acts as the public initializer for the library. It internally calls
         register_all_models() to scan models and register their corresponding CRUD routes.
         """
+        if getattr(self, "auth_enabled", False):
+            auth_kwargs: Dict[str, Any] = {}
+            if self.auth_profile_model is not None:
+                auth_kwargs["profile_model"] = self.auth_profile_model
+            if self.auth_access_cookie_name:
+                auth_kwargs["access_cookie_name"] = self.auth_access_cookie_name
+            if self.auth_refresh_cookie_name:
+                auth_kwargs["refresh_cookie_name"] = self.auth_refresh_cookie_name
+            if self.auth_cookie_path:
+                auth_kwargs["cookie_path"] = self.auth_cookie_path
+            if self.auth_tags is not None:
+                auth_kwargs["tags"] = self.auth_tags
+
+            register_auth_routes(self.api, **auth_kwargs)
+
         self.register_all_models()


### PR DESCRIPTION
## **Summary**

This PR introduces a built‑in authentication module for Lazy Ninja and integrates it directly with  DynamicAPI. It provides JWT‑based authentication, automatic  /auth  route registration, and clean configuration via both code and Django settings—all consistent with Lazy Ninja’s “zero‑boilerplate” philosophy.

The auth module exposes a single helper,  register_auth_routes(), and  DynamicAPI  now supports an  auth  flag to enable these routes automatically.

----------

## **✨ Features Included**

### **1. Full Auth Route Set**

The module registers a complete auth flow:

-   POST /auth/login
-   POST /auth/register
-   POST /auth/refresh
-   GET /auth/me
-   POST /auth/logout

These endpoints implement a standard access/refresh token cycle on top of Django’s  authenticate()  and the project’s  AUTH_USER_MODEL.

----------

### **2. JWT‑Based Authentication**

-   Access and refresh tokens with configurable lifetimes.
-   Signing secret resolution with clear precedence:
    -   settings.LAZY_NINJA_AUTH["JWT_SECRET"]
    -   settings.JWT_SECRET
    -   settings.SECRET_KEY
-   Algorithm resolution via  LAZY_NINJA_AUTH["JWT_ALGORITHM"]  or  settings.JWT_ALGORITHM  (default  "HS256").
-   Robust validation for token type, expiration, and signature.
-   Errors surfaced as Ninja  HttpError  responses.

----------

### **3. Secure Cookie Support (HttpOnly + Secure + Lax)**

-   Access and refresh tokens are set in HttpOnly cookies by default.
-   secure  flag defaults to  not DEBUG, can be overridden via  LAZY_NINJA_AUTH["COOKIE_SECURE"].
-   Cookie names and path are configurable:
    -   access_cookie_name,  refresh_cookie_name,  cookie_path.
-   Logout endpoint clears both cookies automatically.

----------

### **4. Schema Auto‑Generation (User + Optional Profile)**

Using  generate_schema():

-   UserPublicSchema  is generated automatically, excluding the password field.
    
-   ProfileSchema  is generated when a  profile_model  is provided.
    
-   Responses from  /auth/login,  /auth/register, and  /auth/me  return:
    
    `{  "access":  "...",  "refresh":  "...",  "user":  { ...UserPublicSchema... },  "profile":  { ...ProfileSchema... } | null  }`
    

This keeps auth responses aligned with custom user/profile models without manual serializers.

----------

### **5. Centralized, DRY Settings Handling**

The module introduces:

-   _auth_cfg()  – safely reads  settings.LAZY_NINJA_AUTH  (or  {}).
    
-   _get_setting(keys, default)  – resolves configuration in a single, DRY way:
    
    1.  LAZY_NINJA_AUTH[key]
    2.  settings.KEY
    3.  default

This is used for secrets, algorithms, lifetimes, and cookie flags, ensuring consistent precedence across the module.

----------

### **6. DynamicAPI Integration via  auth  Flag**

DynamicAPI  has been extended with optional auth configuration:

`auto_api = DynamicAPI( api, pagination_type=..., is_async=..., auth=True, # Optional overrides:  # auth_profile_model=Profile,  # auth_access_cookie_name="my_access_cookie",  # auth_refresh_cookie_name="my_refresh_cookie",  # auth_cookie_path="/",  # auth_tags=["Auth"], ) auto_api.init()`

Behavior:

-   When  auth=True  (or when  settings.LAZY_NINJA["auth"]  is truthy),  DynamicAPI.init()  calls  register_auth_routes()  automatically.
    
-   auth_profile_model  can be passed directly or resolved from  settings.LAZY_NINJA["profile_model"]  (supports  "app_label.ModelName"  strings or model classes).
    
-   Auth configuration can be driven purely by settings, e.g.:
    
    `LAZY_NINJA = { "auth": True, "profile_model": "accounts.Profile", "pagination_type": "limit-offset", "is_async": True, }`
    

----------

### **7. Smart Handling of the User Model**

To avoid exposing user CRUD when auth is disabled:

-   DynamicAPI  now detects the Django  AUTH_USER_MODEL  via  get_user_model().
-   If  auth  is not enabled, the  User  model is  **skipped**  during automatic CRUD route registration.
-   If  auth  is enabled, the  User  model participates in auto‑generated routes as usual (and can still be excluded via existing  exclude/schema config mechanisms).

This keeps the API surface safer and more intentional by default.

----------

## **Why this feature?**

Authentication is a common, error‑prone concern in Django APIs, especially with custom user/profile models and JWT. Lazy Ninja already automates CRUD; this PR extends that philosophy to auth:

-   No hand‑written serializers for auth.
-   No manual login/register/refresh endpoints.
-   No direct dependency on external JWT packages or boilerplate configuration.
-   A single, coherent way to plug auth into any  NinjaAPI, or into  DynamicAPI  with one flag.

----------

## **Backward Compatibility**

-   ✅ Existing code remains valid:
    -   register_auth_routes(api, ...)  stays as a standalone helper and is entirely optional.
    -   DynamicAPI  can still be used without  auth, behaving as before.
-   ✅ Auth integration is opt‑in: only enabled when  auth=True  or  LAZY_NINJA["auth"]  is set.
-   ✅ Compatible with both sync and async Ninja routes, as auth endpoints are standard Ninja handlers.

----------

## **Next Steps (Future PR Ideas)**

-   Add a  DynamicAPI.create(...)  convenience factory that instantiates  NinjaAPI  +  DynamicAPI  + auth in a single call.
-   Provide decorators/helpers like  @auth_required  to simplify protection of custom endpoints.
-   Add hooks or extension points for login throttling / brute‑force protection.
-   Optionally support more advanced token strategies or pluggable token backends.

----------

## **Conclusion**

This PR introduces a cohesive authentication layer to Lazy Ninja, with:

-   Production‑ready JWT support.
-   Secure cookie handling.
-   Dynamic schema integration with user/profile models.
-   A simple  auth=True  flag on  DynamicAPI  to wire everything up.

It fits the library’s core goal: minimize boilerplate, keep behavior configurable but consistent, and “just work” out of the box for typical Django projects.