### PR TITLE
Fix/prevent n+1 queries on all cruds

### DIFF
--- a/src/lazy_ninja/router/async_router.py
+++ b/src/lazy_ninja/router/async_router.py
@@ -47,19 +47,19 @@ class AsyncModelRouter(BaseModelRouter):
         ) -> List[Any]:
             """List objects with optional filtering and sorting."""
             try:
-                all_items = await self.model_utils.get_all_objects(self.model)
+                queryset = self.get_base_queryset()
 
                 if self.pre_list:
-                    hook_result = await self.hook_executor.execute(self.pre_list, request, all_items)
+                    hook_result = await self.hook_executor.execute(self.pre_list, request, queryset)
                     if hook_result is not None:
-                        all_items = hook_result
+                        queryset = hook_result
                 
                 if q or sort or kwargs:
                     all_items = await self.queryset_filter.apply_filters_async(
-                        all_items, q, sort, order, **kwargs
+                        queryset, q, sort, order, **kwargs
                     )
                 else:
-                    all_items = await sync_to_async(list)(all_items)
+                    all_items = await sync_to_async(list)(queryset)
 
                 serialized_items = []
                 for item in all_items:
@@ -86,7 +86,7 @@ class AsyncModelRouter(BaseModelRouter):
             """Retrieve a single object by ID."""
             try:
                 item_id_value = parse_model_id(self.model, item_id)
-                instance = await self.model_utils.get_object_or_404(self.model, id=item_id_value)
+                instance = await self.model_utils.get_object_or_404(self.get_base_queryset(), id=item_id_value)
                 return await self.response_handler.handle_response(
                     instance, self.detail_schema, self.custom_response, request
                 )
@@ -193,7 +193,7 @@ class AsyncModelRouter(BaseModelRouter):
             """Update an existing object"""
             try:
                 item_id_value = parse_model_id(self.model, item_id)
-                instance = await self.model_utils.get_object_or_404(self.model, id=item_id_value)
+                instance = await self.model_utils.get_object_or_404(self.get_base_queryset(), id=item_id_value)
 
                 if self.before_update:
                     payload = await self.hook_executor.execute(
@@ -230,7 +230,7 @@ class AsyncModelRouter(BaseModelRouter):
             """Update an existing object with file upload support."""
             try:
                 item_id_value = parse_model_id(self.model, item_id)
-                instance = await self.model_utils.get_object_or_404(self.model, id=item_id_value)
+                instance = await self.model_utils.get_object_or_404(self.get_base_queryset(), id=item_id_value)
 
                 if self.before_update:
                     payload = await self.hook_executor.execute(
@@ -274,7 +274,7 @@ class AsyncModelRouter(BaseModelRouter):
             """Delete an object."""
             try:
                 item_id_value = parse_model_id(self.model, item_id)
-                instance = await self.model_utils.get_object_or_404(self.model, id=item_id_value)
+                instance = await self.model_utils.get_object_or_404(self.get_base_queryset(), id=item_id_value)
 
                 if self.before_delete:
                     await self.hook_executor.execute(self.before_delete, request, instance)

--- a/src/lazy_ninja/router/base.py
+++ b/src/lazy_ninja/router/base.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
 from typing import Type, Optional, List, Any
 
-from django.db.models import Model
+from django.db.models import Model, QuerySet
 from ninja import Router, NinjaAPI
 from pydantic import BaseModel
 
 from ..pagination import BasePagination
 from ..file_upload import FileUploadConfig
+from ..utils.base import get_select_related_fields
 
 
 class BaseModelRouter(ABC):
@@ -74,8 +75,19 @@ class BaseModelRouter(ABC):
 
         self.model_name = model.__name__.lower()
         self.paginator_class = pagination_strategy.get_paginator() if pagination_strategy else None
+        self.select_related_fields = get_select_related_fields(model)
 
         self.router = Router()
+
+    def get_base_queryset(self) -> QuerySet:
+        """
+        Returns a QuerySet for this router's model with select_related applied
+        for all ForeignKey fields, preventing N+1 queries.
+        """
+        qs = self.model.objects.all()
+        if self.select_related_fields:
+            qs = qs.select_related(*self.select_related_fields)
+        return qs
 
     @abstractmethod
     def register_list_route(self) -> None:

--- a/src/lazy_ninja/router/sync_router.py
+++ b/src/lazy_ninja/router/sync_router.py
@@ -48,7 +48,7 @@ class SyncModelRouter(BaseModelRouter):
         ) -> Union[QuerySet, Any]:
             """List objects with optional filtering and sorting."""
             try:
-                queryset = self.model.objects.all()
+                queryset = self.get_base_queryset()
                 
                 if self.pre_list:
                     queryset = self.hook_executor.execute(self.pre_list, request, queryset) or queryset
@@ -72,7 +72,7 @@ class SyncModelRouter(BaseModelRouter):
             """Retrieve a single object by ID."""
             try:
                 item_id_value = parse_model_id(self.model, item_id)
-                instance = get_object_or_404(self.model, id=item_id_value)
+                instance = get_object_or_404(self.get_base_queryset(), id=item_id_value)
                 return self.response_handler.handle_response(
                     instance, self.detail_schema, self.custom_response, request
                 )
@@ -179,7 +179,7 @@ class SyncModelRouter(BaseModelRouter):
             """Update an existing object."""
             try:
                 item_id_value = parse_model_id(self.model, item_id)
-                instance = get_object_or_404(self.model, id=item_id_value)
+                instance = get_object_or_404(self.get_base_queryset(), id=item_id_value)
 
                 if self.before_update:
                     payload = self.hook_executor.execute(
@@ -218,7 +218,7 @@ class SyncModelRouter(BaseModelRouter):
             """Update an existing object with file upload support."""
             try:
                 item_id_value = parse_model_id(self.model, item_id)
-                instance = get_object_or_404(self.model, id=item_id_value)
+                instance = get_object_or_404(self.get_base_queryset(), id=item_id_value)
                 
                 if self.before_update:
                     payload = self.hook_executor.execute(
@@ -264,7 +264,7 @@ class SyncModelRouter(BaseModelRouter):
             """Delete an object."""
             try:
                 item_id_value = parse_model_id(self.model, item_id)
-                instance = get_object_or_404(self.model, id=item_id_value)
+                instance = get_object_or_404(self.get_base_queryset(), id=item_id_value)
 
                 if self.before_delete:
                     self.hook_executor.execute(self.before_delete, request, instance)

--- a/src/lazy_ninja/utils/__init__.py
+++ b/src/lazy_ninja/utils/__init__.py
@@ -9,6 +9,7 @@ from .base import (
     get_field_value_safely,
     is_async_context,
     get_pydantic_type,
+    get_select_related_fields,
     # Async versions
     convert_foreign_keys_async,
     serialize_model_instance_async,
@@ -33,6 +34,7 @@ __all__ = [
     'get_field_value_safely',
     'is_async_context',
     'get_pydantic_type',
+    'get_select_related_fields',
     'generate_schema',
     
     # Async versions

--- a/src/lazy_ninja/utils/base.py
+++ b/src/lazy_ninja/utils/base.py
@@ -3,7 +3,7 @@ Core utility functions for lazy-ninja.
 These are the fundamental building blocks used throughout the library.
 """
 import asyncio
-from typing import Type, Any, Dict
+from typing import Type, Any, Dict, List
 from decimal import Decimal
 from asgiref.sync import sync_to_async
 
@@ -142,6 +142,26 @@ def get_pydantic_type(field: models.Field) -> Type:
         return get_pydantic_type(target_field)
     else:
         return str
+
+
+def get_select_related_fields(model: Type[models.Model]) -> List[str]:
+    """
+    Returns a list of ForeignKey field names for use with QuerySet.select_related().
+
+    Passing these to select_related() tells Django to fetch all FK-related rows
+    in the same SQL JOIN, preventing one extra query per FK per row (N+1).
+
+    Args:
+        model: Django model class
+
+    Returns:
+        List of ForeignKey field names
+    """
+    return [
+        field.name
+        for field in model._meta.fields
+        if isinstance(field, models.ForeignKey)
+    ]
 
 
 # Async versions of core functions

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,8 @@
 import pytest
 
+from django.test.utils import CaptureQueriesContext
+from django.db import connection
+
 from tests.models import TestModel
 
 @pytest.mark.django_db
@@ -76,3 +79,39 @@ def test_delete_item(client, create_test_model):
     response = client.delete(url)
     assert response.status_code == 200
     assert TestModel.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_list_items_no_n_plus_1(client, create_test_model):
+    """
+    List endpoint must not produce N+1 queries.
+    With select_related applied, the number of DB queries must stay constant
+    regardless of how many items are in the list.
+    """
+    # Create 3 items each with their own FK category
+    create_test_model(title="A")
+    create_test_model(title="B")
+    create_test_model(title="C")
+
+    url = "/api/test-models/"
+
+    with CaptureQueriesContext(connection) as ctx_3:
+        response = client.get(url)
+    assert response.status_code == 200
+    queries_for_3 = len(ctx_3.captured_queries)
+
+    # Add 3 more items
+    create_test_model(title="D")
+    create_test_model(title="E")
+    create_test_model(title="F")
+
+    with CaptureQueriesContext(connection) as ctx_6:
+        response = client.get(url)
+    assert response.status_code == 200
+    queries_for_6 = len(ctx_6.captured_queries)
+
+    # Query count must not grow linearly with row count
+    assert queries_for_6 == queries_for_3, (
+        f"N+1 detected: {queries_for_3} queries for 3 items but "
+        f"{queries_for_6} queries for 6 items"
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from lazy_ninja.utils import (
     convert_foreign_keys,
     get_pydantic_type,
     get_field_value_safely,
+    get_select_related_fields,
     is_async_context,
 )
 
@@ -120,3 +121,26 @@ def test_is_async_context_true_inside_async_event_loop():
         assert is_async_context() is True
 
     asyncio.run(check())
+
+
+def test_get_select_related_fields_returns_fk_names():
+    """get_select_related_fields should return only ForeignKey field names."""
+    fields = get_select_related_fields(MockModel)
+    assert "category" in fields
+    assert "user" in fields
+    # Non-FK fields must not appear
+    assert "title" not in fields
+    assert "image" not in fields
+    assert "is_active" not in fields
+
+
+def test_get_select_related_fields_no_fk():
+    """get_select_related_fields returns empty list for models without FK fields."""
+
+    class NoFKModel(models.Model):
+        name = models.CharField(max_length=50)
+
+        class Meta:
+            app_label = "tests"
+
+    assert get_select_related_fields(NoFKModel) == []


### PR DESCRIPTION
This pull request introduces a mechanism to automatically apply `select_related` to all ForeignKey fields in model routers, preventing N+1 query problems when listing or retrieving objects. It adds a utility function to extract ForeignKey field names, updates both sync and async routers to use optimized querysets, and includes tests to verify that query counts remain constant regardless of the number of items. 

The most important changes are:

**N+1 Query Prevention:**

* Added `get_select_related_fields` utility to extract all ForeignKey field names from a model for use with `select_related`.
* Introduced a `get_base_queryset` method in `BaseModelRouter` that returns a queryset with `select_related` applied to all ForeignKey fields, and updated all list, retrieve, update, and delete endpoints in both sync and async routers to use this optimized queryset.

**Testing and Validation:**

* Added a test (`test_list_items_no_n_plus_1`) to ensure the list endpoint does not produce N+1 queries, verifying that the number of SQL queries remains constant as the number of items grows.
* Added unit tests for `get_select_related_fields`, confirming it returns ForeignKey field names and behaves correctly for models with and without ForeignKey fields.

**Utilities and Imports:**

* Exported `get_select_related_fields` in the utils package for use throughout the codebase.

These changes collectively ensure more efficient database access patterns and guard against performance degradation due to N+1 query issues.

Closes #50 